### PR TITLE
Add .gitignore for Next.js project

### DIFF
--- a/nextjs-demo/.gitignore
+++ b/nextjs-demo/.gitignore
@@ -1,0 +1,24 @@
+# dependencies
+node_modules
+
+# next.js
+.next
+out
+
+# production
+build
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# env files
+.env*.local
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts
+
+# misc
+.DS_Store


### PR DESCRIPTION
## Summary
- Add standard `.gitignore` file for Next.js project
- Excludes `node_modules`, `.next`, build outputs, and other generated files from version control

## Test plan
- [x] Verify `.gitignore` file is created with correct patterns
- [x] Confirm `node_modules` and `.next` directories are excluded from git tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)