### PR TITLE
feat: Add dashboard page with product table

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,6 +14,7 @@ pre-commit:
       root: nextjs-demo/
       glob: "*.{js,jsx,ts,tsx,json,css,md}"
       run: bun run format
+      stage_fixed: true
 
     # springboot-demo frontend: lint and format
     - name: springboot-demo lint
@@ -25,3 +26,4 @@ pre-commit:
       root: springboot-demo/
       glob: "*.{js,jsx,ts,tsx,json,css,md}"
       run: npm run format
+      stage_fixed: true

--- a/nextjs-demo/src/app/dashboard/page.tsx
+++ b/nextjs-demo/src/app/dashboard/page.tsx
@@ -1,0 +1,74 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  getProducts,
+  getStatusLabel,
+  type ProductStatus,
+} from "@/repository/product-repository";
+
+export const metadata = {
+  title: "ダッシュボード | Next.js Demo",
+  description: "商品一覧を表示するダッシュボードページ",
+};
+
+function StatusBadge({ status }: { status: ProductStatus }) {
+  const colorClasses: Record<ProductStatus, string> = {
+    in_stock: "bg-green-100 text-green-800",
+    low_stock: "bg-yellow-100 text-yellow-800",
+    out_of_stock: "bg-red-100 text-red-800",
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${colorClasses[status]}`}
+    >
+      {getStatusLabel(status)}
+    </span>
+  );
+}
+
+function formatPrice(price: number): string {
+  return new Intl.NumberFormat("ja-JP", {
+    style: "currency",
+    currency: "JPY",
+  }).format(price);
+}
+
+export default async function DashboardPage() {
+  const products = await getProducts();
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-3xl font-bold">ダッシュボード</h1>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>商品名</TableHead>
+            <TableHead className="text-right">価格</TableHead>
+            <TableHead>ステータス</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {products.map((product) => (
+            <TableRow key={product.id}>
+              <TableCell className="font-medium">{product.name}</TableCell>
+              <TableCell className="text-right">
+                {formatPrice(product.price)}
+              </TableCell>
+              <TableCell>
+                <StatusBadge status={product.status} />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/nextjs-demo/src/app/dashboard/page.tsx
+++ b/nextjs-demo/src/app/dashboard/page.tsx
@@ -6,11 +6,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import {
-  getProducts,
-  getStatusLabel,
-  type ProductStatus,
-} from "@/repository/product-repository";
+import { getProducts, getStatusLabel, type ProductStatus } from "@/repository/product-repository";
 
 export const metadata = {
   title: "ダッシュボード | Next.js Demo",
@@ -59,9 +55,7 @@ export default async function DashboardPage() {
           {products.map((product) => (
             <TableRow key={product.id}>
               <TableCell className="font-medium">{product.name}</TableCell>
-              <TableCell className="text-right">
-                {formatPrice(product.price)}
-              </TableCell>
+              <TableCell className="text-right">{formatPrice(product.price)}</TableCell>
               <TableCell>
                 <StatusBadge status={product.status} />
               </TableCell>

--- a/nextjs-demo/src/components/layout/app-sidebar.tsx
+++ b/nextjs-demo/src/components/layout/app-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Home, FileText, Settings } from "lucide-react";
+import { Home, LayoutDashboard, FileText, Settings } from "lucide-react";
 import {
   Sidebar,
   SidebarContent,
@@ -19,6 +19,7 @@ import {
 
 const menuItems = [
   { title: "Home", icon: Home, url: "/" },
+  { title: "Dashboard", icon: LayoutDashboard, url: "/dashboard" },
   { title: "Documents", icon: FileText, url: "/documents" },
   { title: "Settings", icon: Settings, url: "/settings" },
 ];

--- a/nextjs-demo/src/components/ui/table.tsx
+++ b/nextjs-demo/src/components/ui/table.tsx
@@ -1,0 +1,120 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn(
+      "p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+      className
+    )}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/nextjs-demo/src/components/ui/table.tsx
+++ b/nextjs-demo/src/components/ui/table.tsx
@@ -1,40 +1,31 @@
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-const Table = React.forwardRef<
-  HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement>
->(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
-    <table
-      ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
-      {...props}
-    />
-  </div>
-))
-Table.displayName = "Table"
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-auto">
+      <table ref={ref} className={cn("w-full caption-bottom text-sm", className)} {...props} />
+    </div>
+  )
+);
+Table.displayName = "Table";
 
 const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
   <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
-))
-TableHeader.displayName = "TableHeader"
+));
+TableHeader.displayName = "TableHeader";
 
 const TableBody = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <tbody
-    ref={ref}
-    className={cn("[&_tr:last-child]:border-0", className)}
-    {...props}
-  />
-))
-TableBody.displayName = "TableBody"
+  <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+));
+TableBody.displayName = "TableBody";
 
 const TableFooter = React.forwardRef<
   HTMLTableSectionElement,
@@ -42,29 +33,25 @@ const TableFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <tfoot
     ref={ref}
-    className={cn(
-      "border-t bg-muted/50 font-medium [&>tr]:last:border-b-0",
-      className
-    )}
+    className={cn("border-t bg-muted/50 font-medium [&>tr]:last:border-b-0", className)}
     {...props}
   />
-))
-TableFooter.displayName = "TableFooter"
+));
+TableFooter.displayName = "TableFooter";
 
-const TableRow = React.forwardRef<
-  HTMLTableRowElement,
-  React.HTMLAttributes<HTMLTableRowElement>
->(({ className, ...props }, ref) => (
-  <tr
-    ref={ref}
-    className={cn(
-      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
-      className
-    )}
-    {...props}
-  />
-))
-TableRow.displayName = "TableRow"
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(
+        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+TableRow.displayName = "TableRow";
 
 const TableHead = React.forwardRef<
   HTMLTableCellElement,
@@ -78,8 +65,8 @@ const TableHead = React.forwardRef<
     )}
     {...props}
   />
-))
-TableHead.displayName = "TableHead"
+));
+TableHead.displayName = "TableHead";
 
 const TableCell = React.forwardRef<
   HTMLTableCellElement,
@@ -93,28 +80,15 @@ const TableCell = React.forwardRef<
     )}
     {...props}
   />
-))
-TableCell.displayName = "TableCell"
+));
+TableCell.displayName = "TableCell";
 
 const TableCaption = React.forwardRef<
   HTMLTableCaptionElement,
   React.HTMLAttributes<HTMLTableCaptionElement>
 >(({ className, ...props }, ref) => (
-  <caption
-    ref={ref}
-    className={cn("mt-4 text-sm text-muted-foreground", className)}
-    {...props}
-  />
-))
-TableCaption.displayName = "TableCaption"
+  <caption ref={ref} className={cn("mt-4 text-sm text-muted-foreground", className)} {...props} />
+));
+TableCaption.displayName = "TableCaption";
 
-export {
-  Table,
-  TableHeader,
-  TableBody,
-  TableFooter,
-  TableHead,
-  TableRow,
-  TableCell,
-  TableCaption,
-}
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };

--- a/nextjs-demo/src/repository/product-repository.ts
+++ b/nextjs-demo/src/repository/product-repository.ts
@@ -1,0 +1,45 @@
+/**
+ * 商品データのリポジトリ
+ * 現在はモックデータを返すが、将来的にはAPI連携に差し替え可能
+ */
+
+export type ProductStatus = "in_stock" | "low_stock" | "out_of_stock";
+
+export type Product = {
+  id: string;
+  name: string;
+  price: number;
+  status: ProductStatus;
+};
+
+const mockProducts: Product[] = [
+  { id: "1", name: "ワイヤレスイヤホン", price: 12800, status: "in_stock" },
+  { id: "2", name: "スマートウォッチ", price: 34500, status: "in_stock" },
+  { id: "3", name: "ポータブルスピーカー", price: 8900, status: "low_stock" },
+  { id: "4", name: "ノイズキャンセリングヘッドホン", price: 29800, status: "in_stock" },
+  { id: "5", name: "モバイルバッテリー", price: 3980, status: "out_of_stock" },
+  { id: "6", name: "USBハブ", price: 2480, status: "in_stock" },
+  { id: "7", name: "ワイヤレス充電器", price: 4500, status: "low_stock" },
+  { id: "8", name: "タブレットスタンド", price: 1980, status: "in_stock" },
+];
+
+/**
+ * 商品一覧を取得する
+ * 将来的にはAPIからデータを取得するように変更可能
+ */
+export async function getProducts(): Promise<Product[]> {
+  // TODO: API連携時はここをfetchに差し替え
+  return mockProducts;
+}
+
+/**
+ * ステータスの表示ラベルを取得する
+ */
+export function getStatusLabel(status: ProductStatus): string {
+  const labels: Record<ProductStatus, string> = {
+    in_stock: "在庫あり",
+    low_stock: "残りわずか",
+    out_of_stock: "在庫なし",
+  };
+  return labels[status];
+}


### PR DESCRIPTION
## Summary
- shadcn/ui Tableコンポーネントを追加
- 商品データのリポジトリを作成（モックデータ、将来的にAPI連携可能な設計）
- `/dashboard` に商品一覧テーブルを表示するダッシュボードページを作成
- サイドバーにダッシュボードへのナビゲーションリンクを追加

## Test plan
- [ ] `bun run dev` で開発サーバーを起動
- [ ] http://localhost:3000/dashboard にアクセスして商品テーブルが表示されることを確認
- [ ] サイドバーの「Dashboard」リンクからページ遷移できることを確認
- [ ] 商品名、価格（¥形式）、ステータスバッジが正しく表示されることを確認
- [ ] `bun run build` でビルドが成功することを確認